### PR TITLE
Fixed first digit always 0 on send page

### DIFF
--- a/frontend/src/Pages/Send.jsx
+++ b/frontend/src/Pages/Send.jsx
@@ -58,7 +58,7 @@ function Send() {
             <input 
               type="number" 
               value={amount}
-              onChange={(e) => setAmount(Number(e.target.value))}
+              onChange={(e) => setAmount(e.target.value)}
               className="w-full border border-blue-200 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-600" 
               placeholder="0.00" 
             />


### PR DESCRIPTION
This PR fixes #4 where the first digit was always 0 on the send page